### PR TITLE
Fix threading problem when SDK inits

### DIFF
--- a/ios/Classes/SwiftOptimizelyFlutterSdkPlugin.swift
+++ b/ios/Classes/SwiftOptimizelyFlutterSdkPlugin.swift
@@ -225,13 +225,15 @@ public class SwiftOptimizelyFlutterSdkPlugin: NSObject, FlutterPlugin {
             settings: optimizelySdkSettings,
             cmabConfig: cmabConfig)
         
-        optimizelyInstance.start{ [weak self] res in
-            switch res {
-            case .success(_):
-                self?.optimizelyClientsTracker[sdkKey] = optimizelyInstance
-                result(self?.createResponse(success: true))
-            case .failure(let err):
-                result(self?.createResponse(success: false, reason: err.localizedDescription))
+        optimizelyInstance.start { [weak self] res in
+            DispatchQueue.main.async {
+                switch res {
+                    case .success(_):
+                    self?.optimizelyClientsTracker[sdkKey] = optimizelyInstance
+                    result(self?.createResponse(success: true))
+                    case .failure(let err):
+                    result(self?.createResponse(success: false, reason: err.localizedDescription))
+                }
             }
         }
     }


### PR DESCRIPTION
It should fix the crash: https://findhotel.sentry.io/issues/7245666115/?project=4508398661074946
We dispatch the callback from SDK initialization back to the main thread.

Looks that the Swift SDK can call us back on an arbitrary queue, while it should be the main queue the communicate via Flutter channels as far as I am aware.

Also, there's some state modification in that callback block, which doesn't look like it's thread safe.

When investigating the Swift SDK I could confirm, that the work is dispatcher on the background thread and never disptached back to main when calling bak the original start caller:
https://github.com/optimizely/swift-sdk/blob/fdefe531d3c4c44eff7f77f7d32dd20fbfd984e5/Sources/Optimizely/OptimizelyClient.swift#L146
https://github.com/optimizely/swift-sdk/blob/fdefe531d3c4c44eff7f77f7d32dd20fbfd984e5/Sources/Customization/DefaultDatafileHandler.swift#L67